### PR TITLE
Implement `MyMap::into_inner` and remove Deref antipattern

### DIFF
--- a/src/gsn/check.rs
+++ b/src/gsn/check.rs
@@ -1,6 +1,5 @@
 use super::GsnNode;
 use crate::diagnostics::Diagnostics;
-use crate::yaml_fix::MyMap;
 use std::collections::{BTreeMap, BTreeSet};
 
 ///
@@ -9,7 +8,7 @@ use std::collections::{BTreeMap, BTreeSet};
 ///
 pub fn check_nodes(
     diag: &mut Diagnostics,
-    nodes: &MyMap<String, GsnNode>,
+    nodes: &BTreeMap<String, GsnNode>,
     excluded_modules: Option<Vec<&str>>,
 ) {
     check_node_references(diag, nodes, excluded_modules);
@@ -28,7 +27,7 @@ pub fn check_nodes(
 ///
 fn check_root_nodes(
     diag: &mut Diagnostics,
-    nodes: &MyMap<String, GsnNode>,
+    nodes: &BTreeMap<String, GsnNode>,
 ) -> Result<Vec<String>, ()> {
     let root_nodes = super::get_root_nodes(nodes);
     match root_nodes.len() {
@@ -78,7 +77,7 @@ fn check_root_nodes(
 ///
 fn check_node_references(
     diag: &mut Diagnostics,
-    nodes: &MyMap<String, GsnNode>,
+    nodes: &BTreeMap<String, GsnNode>,
     excluded_modules: Option<Vec<&str>>,
 ) {
     let ex_mods = excluded_modules.iter().flatten().collect::<Vec<_>>();
@@ -119,7 +118,7 @@ fn check_node_references(
 /// It also detects if there is a cycle in an independent graph.
 ///
 ///
-fn check_cycles(diag: &mut Diagnostics, nodes: &MyMap<String, GsnNode>) {
+fn check_cycles(diag: &mut Diagnostics, nodes: &BTreeMap<String, GsnNode>) {
     let mut visited: BTreeSet<String> = BTreeSet::new();
     let root_nodes = super::get_root_nodes(nodes);
     let cloned_root_nodes = root_nodes.to_vec();
@@ -211,7 +210,7 @@ fn check_cycles(diag: &mut Diagnostics, nodes: &MyMap<String, GsnNode>) {
 ///
 ///
 ///
-fn check_levels(diag: &mut Diagnostics, nodes: &MyMap<String, GsnNode>) {
+fn check_levels(diag: &mut Diagnostics, nodes: &BTreeMap<String, GsnNode>) {
     let mut levels = BTreeMap::<&str, usize>::new();
     for node in nodes.values() {
         if let Some(l) = &node.level {
@@ -229,7 +228,7 @@ fn check_levels(diag: &mut Diagnostics, nodes: &MyMap<String, GsnNode>) {
 /// are actually used at at least one node.
 /// Also checks if no reserved words are used, like 'level' or 'text'
 ///
-pub fn check_layers(diag: &mut Diagnostics, nodes: &MyMap<String, GsnNode>, layers: &[&str]) {
+pub fn check_layers(diag: &mut Diagnostics, nodes: &BTreeMap<String, GsnNode>, layers: &[&str]) {
     let reserved_words = [
         "text",
         "inContextOf",
@@ -270,7 +269,7 @@ mod test {
     #[test]
     fn unresolved_ref_context() {
         let mut d = Diagnostics::default();
-        let mut nodes = MyMap::<String, GsnNode>::new();
+        let mut nodes = BTreeMap::<String, GsnNode>::new();
         nodes.insert(
             "G1".to_owned(),
             GsnNode {
@@ -294,7 +293,7 @@ mod test {
     #[test]
     fn unresolved_ref_support() {
         let mut d = Diagnostics::default();
-        let mut nodes = MyMap::<String, GsnNode>::new();
+        let mut nodes = BTreeMap::<String, GsnNode>::new();
         nodes.insert(
             "G1".to_owned(),
             GsnNode {
@@ -317,7 +316,7 @@ mod test {
     #[test]
     fn unreferenced_id() {
         let mut d = Diagnostics::default();
-        let mut nodes = MyMap::<String, GsnNode>::new();
+        let mut nodes = BTreeMap::<String, GsnNode>::new();
         nodes.insert(
             "G1".to_owned(),
             GsnNode {
@@ -341,7 +340,7 @@ mod test {
     #[test]
     fn simple_cycle() {
         let mut d = Diagnostics::default();
-        let mut nodes = MyMap::<String, GsnNode>::new();
+        let mut nodes = BTreeMap::<String, GsnNode>::new();
         nodes.insert(
             "G0".to_owned(),
             GsnNode {
@@ -378,7 +377,7 @@ mod test {
     #[test]
     fn simple_cycle_2() {
         let mut d = Diagnostics::default();
-        let mut nodes = MyMap::<String, GsnNode>::new();
+        let mut nodes = BTreeMap::<String, GsnNode>::new();
         nodes.insert(
             "G1".to_owned(),
             GsnNode {
@@ -415,7 +414,7 @@ mod test {
     #[test]
     fn diamond() {
         let mut d = Diagnostics::default();
-        let mut nodes = MyMap::<String, GsnNode>::new();
+        let mut nodes = BTreeMap::<String, GsnNode>::new();
         nodes.insert(
             "G1".to_owned(),
             GsnNode {
@@ -453,7 +452,7 @@ mod test {
     #[test]
     fn independent_cycle() {
         let mut d = Diagnostics::default();
-        let mut nodes = MyMap::<String, GsnNode>::new();
+        let mut nodes = BTreeMap::<String, GsnNode>::new();
         nodes.insert(
             "G1".to_owned(),
             GsnNode {
@@ -524,7 +523,7 @@ mod test {
     #[test]
     fn wrong_root() {
         let mut d = Diagnostics::default();
-        let mut nodes = MyMap::<String, GsnNode>::new();
+        let mut nodes = BTreeMap::<String, GsnNode>::new();
         nodes.insert("Sn1".to_owned(), GsnNode::default());
         check_nodes(&mut d, &nodes, None);
         assert_eq!(d.messages.len(), 1);
@@ -541,9 +540,9 @@ mod test {
     #[test]
     fn layer_exists() {
         let mut d = Diagnostics::default();
-        let mut nodes = MyMap::<String, GsnNode>::new();
+        let mut nodes = BTreeMap::<String, GsnNode>::new();
 
-        let mut admap = MyMap::new();
+        let mut admap = BTreeMap::new();
         admap.insert("layer1".to_owned(), "dontcare".to_owned());
         nodes.insert(
             "Sn1".to_owned(),
@@ -561,7 +560,7 @@ mod test {
     #[test]
     fn layer_does_not_exist() {
         let mut d = Diagnostics::default();
-        let mut nodes = MyMap::<String, GsnNode>::new();
+        let mut nodes = BTreeMap::<String, GsnNode>::new();
 
         nodes.insert("Sn1".to_owned(), GsnNode::default());
         check_layers(&mut d, &nodes, &["layer1"]);
@@ -579,9 +578,9 @@ mod test {
     #[test]
     fn only_one_layer_exists() {
         let mut d = Diagnostics::default();
-        let mut nodes = MyMap::<String, GsnNode>::new();
+        let mut nodes = BTreeMap::<String, GsnNode>::new();
 
-        let mut admap = MyMap::new();
+        let mut admap = BTreeMap::new();
         admap.insert("layer1".to_owned(), "dontcare".to_owned());
         nodes.insert(
             "Sn1".to_owned(),
@@ -605,9 +604,9 @@ mod test {
     #[test]
     fn layer_reserved() {
         let mut d = Diagnostics::default();
-        let mut nodes = MyMap::<String, GsnNode>::new();
+        let mut nodes = BTreeMap::<String, GsnNode>::new();
 
-        let mut admap = MyMap::new();
+        let mut admap = BTreeMap::new();
         admap.insert("layer1".to_owned(), "dontcare".to_owned());
         nodes.insert(
             "Sn1".to_owned(),
@@ -637,7 +636,7 @@ mod test {
     #[test]
     fn level_only_once() {
         let mut d = Diagnostics::default();
-        let mut nodes = MyMap::<String, GsnNode>::new();
+        let mut nodes = BTreeMap::<String, GsnNode>::new();
         nodes.insert(
             "G1".to_owned(),
             GsnNode {
@@ -658,7 +657,7 @@ mod test {
     #[test]
     fn empty_document() {
         let mut d = Diagnostics::default();
-        let nodes = MyMap::<String, GsnNode>::new();
+        let nodes = BTreeMap::<String, GsnNode>::new();
         assert!(check_root_nodes(&mut d, &nodes).is_ok());
         assert_eq!(d.messages.len(), 0);
     }

--- a/src/gsn/mod.rs
+++ b/src/gsn/mod.rs
@@ -1,5 +1,4 @@
 use crate::dirgraphsvg::edges::{EdgeType, SingleEdge};
-use crate::yaml_fix::MyMap;
 use serde::Deserialize;
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -21,7 +20,7 @@ pub struct GsnNode {
     pub(crate) url: Option<String>,
     pub(crate) level: Option<String>,
     #[serde(flatten)]
-    pub(crate) additional: MyMap<String, String>,
+    pub(crate) additional: BTreeMap<String, String>,
     #[serde(skip_deserializing)]
     pub(crate) module: String,
 }
@@ -53,7 +52,7 @@ pub struct ModuleInformation {
     pub(crate) name: String,
     pub(crate) brief: Option<String>,
     #[serde(flatten)]
-    pub(crate) additional: MyMap<String, String>,
+    pub(crate) additional: BTreeMap<String, String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -72,7 +71,7 @@ pub struct Module {
 /// Get root nodes
 /// These are the unreferenced nodes.
 ///
-fn get_root_nodes(nodes: &MyMap<String, GsnNode>) -> Vec<String> {
+fn get_root_nodes(nodes: &BTreeMap<String, GsnNode>) -> Vec<String> {
     // Usage of BTreeSet, since root nodes might be used in output and that should be deterministic
     let mut root_nodes: BTreeSet<String> = nodes.keys().cloned().collect();
     for node in nodes.values() {
@@ -94,7 +93,7 @@ fn get_root_nodes(nodes: &MyMap<String, GsnNode>) -> Vec<String> {
 ///
 /// Gathers all different 'level' attributes from all nodes.
 ///
-pub fn get_levels(nodes: &MyMap<String, GsnNode>) -> BTreeMap<&str, Vec<&str>> {
+pub fn get_levels(nodes: &BTreeMap<String, GsnNode>) -> BTreeMap<&str, Vec<&str>> {
     let mut levels = BTreeMap::<&str, Vec<&str>>::new();
     for (id, node) in nodes.iter() {
         if let Some(l) = &node.level {
@@ -110,7 +109,7 @@ pub fn get_levels(nodes: &MyMap<String, GsnNode>) -> BTreeMap<&str, Vec<&str>> {
 ///
 ///
 pub fn calculate_module_dependencies(
-    nodes: &MyMap<String, GsnNode>,
+    nodes: &BTreeMap<String, GsnNode>,
 ) -> BTreeMap<String, BTreeMap<String, EdgeType>> {
     let mut res = BTreeMap::<String, BTreeMap<String, EdgeType>>::new();
 
@@ -137,7 +136,7 @@ pub fn calculate_module_dependencies(
 ///
 fn add_dependencies(
     children: &Vec<String>,
-    nodes: &MyMap<String, GsnNode>,
+    nodes: &BTreeMap<String, GsnNode>,
     cur_node: &GsnNode,
     dependencies: &mut BTreeMap<String, BTreeMap<String, EdgeType>>,
     dep_type: SingleEdge,
@@ -197,7 +196,7 @@ mod test {
 
     #[test]
     fn no_level_exists() {
-        let mut nodes = MyMap::<String, GsnNode>::new();
+        let mut nodes = BTreeMap::<String, GsnNode>::new();
         nodes.insert("Sn1".to_owned(), Default::default());
         let output = get_levels(&nodes);
         assert!(output.is_empty());
@@ -205,7 +204,7 @@ mod test {
 
     #[test]
     fn two_levels_exist() {
-        let mut nodes = MyMap::<String, GsnNode>::new();
+        let mut nodes = BTreeMap::<String, GsnNode>::new();
         nodes.insert(
             "Sn1".to_owned(),
             GsnNode {

--- a/src/gsn/validation.rs
+++ b/src/gsn/validation.rs
@@ -1,13 +1,12 @@
 use super::GsnNode;
 use crate::diagnostics::{DiagType, Diagnostics};
-use crate::yaml_fix::MyMap;
-use std::collections::HashSet;
+use std::collections::{HashSet, BTreeMap};
 
 ///
 /// Validate all ids and nodes
 ///
 ///
-pub fn validate_module(diag: &mut Diagnostics, module: &str, nodes: &MyMap<String, GsnNode>) {
+pub fn validate_module(diag: &mut Diagnostics, module: &str, nodes: &BTreeMap<String, GsnNode>) {
     for (id, node) in nodes.iter().filter(|(_, n)| n.module == module) {
         // Validate if key is one of the known prefixes
         validate_id(diag, module, id);
@@ -160,7 +159,7 @@ mod test {
     #[test]
     fn self_ref_context() {
         let mut d = Diagnostics::default();
-        let mut nodes = MyMap::<String, GsnNode>::new();
+        let mut nodes = BTreeMap::<String, GsnNode>::new();
         nodes.insert(
             "C1".to_owned(),
             GsnNode {
@@ -189,7 +188,7 @@ mod test {
     #[test]
     fn self_ref_support() {
         let mut d = Diagnostics::default();
-        let mut nodes = MyMap::<String, GsnNode>::new();
+        let mut nodes = BTreeMap::<String, GsnNode>::new();
         nodes.insert(
             "G1".to_owned(),
             GsnNode {
@@ -212,7 +211,7 @@ mod test {
     #[test]
     fn self_ref_wrong_context() {
         let mut d = Diagnostics::default();
-        let mut nodes = MyMap::<String, GsnNode>::new();
+        let mut nodes = BTreeMap::<String, GsnNode>::new();
         nodes.insert(
             "C1".to_owned(),
             GsnNode {
@@ -241,7 +240,7 @@ mod test {
     #[test]
     fn self_ref_wrong_support() {
         let mut d = Diagnostics::default();
-        let mut nodes = MyMap::<String, GsnNode>::new();
+        let mut nodes = BTreeMap::<String, GsnNode>::new();
         nodes.insert(
             "G1".to_owned(),
             GsnNode {
@@ -271,7 +270,7 @@ mod test {
     #[test]
     fn duplicate_ref_context() {
         let mut d = Diagnostics::default();
-        let mut nodes = MyMap::<String, GsnNode>::new();
+        let mut nodes = BTreeMap::<String, GsnNode>::new();
         nodes.insert(
             "G1".to_owned(),
             GsnNode {
@@ -297,7 +296,7 @@ mod test {
     #[test]
     fn duplicate_ref_support() {
         let mut d = Diagnostics::default();
-        let mut nodes = MyMap::<String, GsnNode>::new();
+        let mut nodes = BTreeMap::<String, GsnNode>::new();
         nodes.insert(
             "G1".to_owned(),
             GsnNode {
@@ -327,7 +326,7 @@ mod test {
     #[test]
     fn wrong_ref_context() {
         let mut d = Diagnostics::default();
-        let mut nodes = MyMap::<String, GsnNode>::new();
+        let mut nodes = BTreeMap::<String, GsnNode>::new();
         nodes.insert(
             "G1".to_owned(),
             GsnNode {
@@ -378,7 +377,7 @@ mod test {
     #[test]
     fn wrong_ref_support() {
         let mut d = Diagnostics::default();
-        let mut nodes = MyMap::<String, GsnNode>::new();
+        let mut nodes = BTreeMap::<String, GsnNode>::new();
         nodes.insert(
             "G1".to_owned(),
             GsnNode {
@@ -416,7 +415,7 @@ mod test {
     #[test]
     fn undeveloped_goal() {
         let mut d = Diagnostics::default();
-        let mut nodes = MyMap::<String, GsnNode>::new();
+        let mut nodes = BTreeMap::<String, GsnNode>::new();
         nodes.insert("G1".to_owned(), GsnNode::default());
         nodes.insert(
             "G2".to_owned(),
@@ -440,7 +439,7 @@ mod test {
     #[test]
     fn undeveloped_strategy() {
         let mut d = Diagnostics::default();
-        let mut nodes = MyMap::<String, GsnNode>::new();
+        let mut nodes = BTreeMap::<String, GsnNode>::new();
         nodes.insert("S1".to_owned(), GsnNode::default());
         nodes.insert(
             "S2".to_owned(),
@@ -464,7 +463,7 @@ mod test {
     #[test]
     fn wrong_undeveloped() {
         let mut d = Diagnostics::default();
-        let mut nodes = MyMap::<String, GsnNode>::new();
+        let mut nodes = BTreeMap::<String, GsnNode>::new();
         nodes.insert(
             "G1".to_owned(),
             GsnNode {

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,7 +1,6 @@
 use crate::dirgraphsvg::edges::EdgeType;
 use crate::dirgraphsvg::{escape_node_id, escape_text, nodes::*};
 use crate::gsn::{get_levels, GsnNode, Module};
-use crate::yaml_fix::MyMap;
 use chrono::Utc;
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap};
@@ -233,7 +232,7 @@ pub fn render_architecture(
 pub fn render_complete(
     output: &mut impl Write,
     _matches: &clap::ArgMatches,
-    nodes: &MyMap<String, GsnNode>,
+    nodes: &BTreeMap<String, GsnNode>,
     stylesheets: Option<Vec<&str>>,
 ) -> Result<(), anyhow::Error> {
     // let masked_modules_opt = matches
@@ -278,7 +277,7 @@ pub fn render_argument(
     matches: &clap::ArgMatches,
     module_name: &str,
     modules: &HashMap<String, Module>,
-    nodes: &MyMap<String, GsnNode>,
+    nodes: &BTreeMap<String, GsnNode>,
     stylesheets: Option<Vec<&str>>,
 ) -> Result<(), anyhow::Error> {
     let mut dg = crate::dirgraphsvg::DirGraph::default();
@@ -364,7 +363,7 @@ pub fn render_argument(
 
 pub(crate) fn render_evidences(
     output: &mut impl Write,
-    nodes: &MyMap<String, GsnNode>,
+    nodes: &BTreeMap<String, GsnNode>,
     layers: &Option<Vec<&str>>,
 ) -> Result<(), anyhow::Error> {
     writeln!(output)?;

--- a/src/yaml_fix.rs
+++ b/src/yaml_fix.rs
@@ -22,24 +22,9 @@ impl<K: Ord, V> MyMap<K, V> {
     pub fn new() -> MyMap<K, V> {
         MyMap(BTreeMap::<K, V>::new())
     }
-}
 
-impl<K, V> std::ops::Deref for MyMap<K, V>
-where
-    K: Ord,
-{
-    type Target = BTreeMap<K, V>;
-    fn deref(&self) -> &BTreeMap<K, V> {
-        &self.0
-    }
-}
-
-impl<K, V> std::ops::DerefMut for MyMap<K, V>
-where
-    K: Ord,
-{
-    fn deref_mut(&mut self) -> &mut BTreeMap<K, V> {
-        &mut self.0
+    pub fn into_inner(self) -> BTreeMap<K, V> {
+        self.0
     }
 }
 


### PR DESCRIPTION
This ended up being a pretty easy refactoring. I especially like that the rest of the implementation now uses the standard `BTreeMap`, which makes it easier for people unfamiliar with the project to know what it is / how it can be used.

I saw a couple of other things that could be improved while doing the refactoring. I'll contribute some more changes when I find the time. 