### PR TITLE
Reduce equivalent states in GsnNode

### DIFF
--- a/src/gsn/check.rs
+++ b/src/gsn/check.rs
@@ -274,7 +274,7 @@ mod test {
             "G1".to_owned(),
             GsnNode {
                 in_context_of: Some(vec!["C1".to_owned()]),
-                undeveloped: Some(true),
+                undeveloped: true,
                 ..Default::default()
             },
         );
@@ -320,7 +320,7 @@ mod test {
         nodes.insert(
             "G1".to_owned(),
             GsnNode {
-                undeveloped: Some(true),
+                undeveloped: true,
                 ..Default::default()
             },
         );
@@ -432,7 +432,7 @@ mod test {
         nodes.insert(
             "G2".to_owned(),
             GsnNode {
-                undeveloped: Some(true),
+                undeveloped: true,
                 ..Default::default()
             },
         );
@@ -491,7 +491,7 @@ mod test {
         nodes.insert(
             "G4".to_owned(),
             GsnNode {
-                undeveloped: Some(true),
+                undeveloped: true,
                 in_context_of: Some(vec!["J1".to_owned()]),
                 ..Default::default()
             },
@@ -640,7 +640,7 @@ mod test {
         nodes.insert(
             "G1".to_owned(),
             GsnNode {
-                undeveloped: Some(true),
+                undeveloped: true,
                 level: Some("test".to_owned()),
                 ..Default::default()
             },

--- a/src/gsn/mod.rs
+++ b/src/gsn/mod.rs
@@ -15,7 +15,8 @@ pub struct GsnNode {
     pub(crate) text: String,
     pub(crate) in_context_of: Option<Vec<String>>,
     pub(crate) supported_by: Option<Vec<String>>,
-    pub(crate) undeveloped: Option<bool>,
+    #[serde(default)]
+    pub(crate) undeveloped: bool,
     pub(crate) classes: Option<Vec<String>>,
     pub(crate) url: Option<String>,
     pub(crate) level: Option<String>,

--- a/src/gsn/validation.rs
+++ b/src/gsn/validation.rs
@@ -70,14 +70,14 @@ fn validate_references(diag: &mut Diagnostics, module: &str, id: &str, node: &Gs
             "supported by element",
             &valid_refs,
         );
-        if Some(true) == node.undeveloped {
+        if node.undeveloped {
             diag.add_error(
                 Some(module),
                 format!("V03: Undeveloped element {} has supporting arguments.", id),
             );
         }
     } else if (id.starts_with('S') && !id.starts_with("Sn") || id.starts_with('G'))
-        && (Some(false) == node.undeveloped || node.undeveloped.is_none())
+        && !node.undeveloped
     {
         // No "supported by" entries, but Strategy and Goal => undeveloped
         diag.add_warning(Some(module), format!("V02: Element {} is undeveloped.", id));
@@ -245,7 +245,7 @@ mod test {
             "G1".to_owned(),
             GsnNode {
                 in_context_of: Some(vec!["G1".to_owned()]),
-                undeveloped: Some(true),
+                undeveloped: true,
                 ..Default::default()
             },
         );
@@ -307,7 +307,7 @@ mod test {
         nodes.insert(
             "G2".to_owned(),
             GsnNode {
-                undeveloped: Some(true),
+                undeveloped: true,
                 ..Default::default()
             },
         );
@@ -331,21 +331,21 @@ mod test {
             "G1".to_owned(),
             GsnNode {
                 in_context_of: Some(vec!["G2".to_owned(), "S1".to_owned(), "Sn1".to_owned()]),
-                undeveloped: Some(true),
+                undeveloped: true,
                 ..Default::default()
             },
         );
         nodes.insert(
             "G2".to_owned(),
             GsnNode {
-                undeveloped: Some(true),
+                undeveloped: true,
                 ..Default::default()
             },
         );
         nodes.insert(
             "S1".to_owned(),
             GsnNode {
-                undeveloped: Some(true),
+                undeveloped: true,
                 ..Default::default()
             },
         );
@@ -420,7 +420,7 @@ mod test {
         nodes.insert(
             "G2".to_owned(),
             GsnNode {
-                undeveloped: Some(false),
+                undeveloped: false,
                 ..Default::default()
             },
         );
@@ -444,7 +444,7 @@ mod test {
         nodes.insert(
             "S2".to_owned(),
             GsnNode {
-                undeveloped: Some(false),
+                undeveloped: false,
                 ..Default::default()
             },
         );
@@ -468,7 +468,7 @@ mod test {
             "G1".to_owned(),
             GsnNode {
                 supported_by: Some(vec!["Sn2".to_owned()]),
-                undeveloped: Some(true),
+                undeveloped: true,
                 ..Default::default()
             },
         );

--- a/src/render.rs
+++ b/src/render.rs
@@ -40,7 +40,7 @@ pub fn svg_from_gsn_node(
         id if id.starts_with('G') => new_goal(
             id,
             &gsn_node.text,
-            gsn_node.undeveloped.unwrap_or(false),
+            gsn_node.undeveloped,
             gsn_node.url.to_owned(),
             classes,
         ),
@@ -50,7 +50,7 @@ pub fn svg_from_gsn_node(
         id if id.starts_with('S') => new_strategy(
             id,
             &gsn_node.text,
-            gsn_node.undeveloped.unwrap_or(false),
+            gsn_node.undeveloped,
             gsn_node.url.to_owned(),
             classes,
         ),
@@ -123,7 +123,7 @@ pub fn away_svg_from_gsn_node(
         id if id.starts_with('S') => new_strategy(
             id,
             &gsn_node.text,
-            gsn_node.undeveloped.unwrap_or(false),
+            gsn_node.undeveloped,
             gsn_node.url.to_owned(),
             classes,
         ),


### PR DESCRIPTION
Hi Jonas,

I just had another look at your library and have a suggestion for an improvement:

In the `GsnNode`, most attributes are of type `Option<...>`. This makes sense as the corresponding yaml keys are optional as well and using `Option<...>` automatically makes serde work. For some of these fields, having an optional value doesn't really make sense though as the `None` case is treated the same as a value of the inner type. For example, for the `undeveloped` field (which is of type `Option<bool>`), the values `None` and `Some(false)` are treated the same in the whole codebase. Having two represenations of the same state makes the code less efficient, more complex and can introduce subtle bugs. 

Serde has a field attribute `#[serde(default)]` which describes that if the corresponding field isn't defined in the yaml file, the field will be initialized with a default value. In the example of the `undeveloped` field, this makes it possible to change the type to `bool`. If the `undeveloped` key isn't specified in the yaml file, the field will be initialized with `false` (bool's default value).

Using `bool` instead of `Option<bool>` simplifies the handling in the rest of the codebase, see the diff below. It doesn't change the behaviour of the program, except that it should be a bit more efficient.

The same trick is probably possible for the other fields. For example, the `in_context_of` field could be changed to `Vec<String>`, with the empty vector being the default value if the key isn't specified. If I see that correctly, the codebase doesn't differentiate between a `None` value and an empty vector. It would allow to change a lot of `.iter().flatten()` calls to simple `.iter()` calls.

I did the refactoring for the `undeveloped` field in this PR, which was straight-forward and quite fun actually. If you want, I can also do the same for the other fields.

Let me know if you have questions, also regarding working with PRs. I'm happy to help.