### PR TITLE
Add Dockerfile to support running in different Linux environments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM rust:1.90.0-trixie AS build
+
+WORKDIR /app
+
+# Reuse cache layer for faster build
+COPY Cargo.lock Cargo.toml ./
+RUN mkdir src \
+    && echo "// dummy file" > src/lib.rs \
+    && cargo build --release
+
+COPY src src
+RUN cargo build --locked --release
+RUN cp ./target/release/gsn2x /usr/local/bin/gsn2x
+
+# Optimize image size with multi-stage
+FROM debian:trixie-slim AS final
+COPY --from=build /usr/local/bin/gsn2x /usr/local/bin/
+
+ENTRYPOINT ["gsn2x"]

--- a/README.md
+++ b/README.md
@@ -33,11 +33,11 @@ The output is an argument view in SVG format and automatically written to `<your
 
 Build the docker image:
 
-  docker build -t gsn2x .
+    docker build -t gsn2x .
 
 Run the docker image interactively:
 
-docker run --interactive --rm --volume $(pwd):/home --workdir /home gsn2x <yourgsnfile.yaml>
+    docker run --interactive --rm --volume $(pwd):/home --workdir /home gsn2x <yourgsnfile.yaml>
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,16 @@ You can create an SVG like this:
 
 The output is an argument view in SVG format and automatically written to `<yourgsnfile.svg>`. If more than one input file is provided, they are treated as modules.
 
+### Docker
+
+Build the docker image:
+
+  docker build -t gsn2x .
+
+Run the docker image interactively:
+
+docker run --interactive --rm --volume $(pwd):/home --workdir /home gsn2x <yourgsnfile.yaml>
+
 ## Documentation
 
 For further information see the [documentation](https://jonasthewolf.github.io/gsn2x).


### PR DESCRIPTION
gsn2x has a number of dependencies which may not be met by the User's machine. Providing a Dockerfile enables the user to create and run their own container.